### PR TITLE
Multi-select: Group selection with previous on Cmd/Ctrl click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15732,11 +15732,6 @@
         "vue-style-loader": "^4.1.0"
       }
     },
-    "vue-page-transition": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vue-page-transition/-/vue-page-transition-0.2.2.tgz",
-      "integrity": "sha512-qOx+llJ28XX0VwJNJ4GVaeNBPRmPMZac2QQgrIHVUhpXyJx2CQ2XvoQOpGD1ge7QMY3PjZ6fwTbdBwZkA3I9qA=="
-    },
     "vue-router": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -203,14 +203,18 @@ class SelectionState {
         action.selection.active,
       );
 
-      if (action.wasGroupClick) {
-        if (!active) {
-          // Clear last selection on group deselection
-          // to avoid updating it on next selection
-          g_group.lastSelection = null;
+      if (!active) {
+        // If deselecting (not active) clear last selection
+        // to avoid updating it on next selection
+        g_group.lastSelection = null;
+      } else {
+        if (!action.wasGroupClick) {
+          // New selection without a group
+          g_group.reset();
         } else {
-          // Add new selection to group
           if (g_group.lastSelection) {
+            // Add new selection to group
+
             // Update last selected deco to be in group the if it's not
             const prevSelectedDeco = this.findDecoOfSelection(g_group.lastSelection.id);
             const prevSelection = prevSelectedDeco.type.spec.selection;
@@ -229,12 +233,12 @@ class SelectionState {
                 deco(prevSelectedDeco.from, prevSelectedDeco.to, updatedPrevSelection),
               ]);
             }
-
-            newSelection.groupId = g_group.id;
           }
 
-          g_group.lastSelection = newSelection;
+          newSelection.groupId = g_group.id;
         }
+
+        g_group.lastSelection = newSelection;
       }
 
       decos = decos.remove([selectedDeco]);
@@ -273,19 +277,6 @@ export const selectionPlugin = new Plugin({
 // Selection UI
 
 export function selectionUI(dispatch) {
-  function modiferPressed(event) {
-    return event.ctrlKey || event.metaKey;
-  }
-
-  function resetGroupOnModifierPress(event) {
-    if (modiferPressed(event)) {
-      g_group.reset();
-    }
-  }
-
-  document.addEventListener('keydown', resetGroupOnModifierPress);
-  document.addEventListener('keyup', resetGroupOnModifierPress);
-
   function handleClick(view, _, event) {
     // Remember to return true to stop prosemirror parent selection on ctrl clicking
 


### PR DESCRIPTION
Past: Required to hold Cmd/Ctrl when selecting all sentences of a group
Now: Only hold Cmd/Ctrl after the first selection of a group. (Not the first)