### PR TITLE
Use whitespace class instead of space in end of sentence regex

### DIFF
--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -8,7 +8,7 @@ import { Decoration, DecorationSet } from "prosemirror-view";
 import store from "../store";
 
 // End of sentence punctuation
-const EOSPuncRegex = /([.?!]) /g;
+const EOSPuncRegex = /([.?!])\s/g;
 const nonWhitespaceRegex = /[^\s\\]/;
 // Styled in Home.js
 const sentenceClasses = {


### PR DESCRIPTION
This fixes a really hard-to-reproduce error that sometimes happened when sentences were separated by two spaces instead of one. The error only seemed to happen when pasting rich text, not plain text.

Resolves issue #18 